### PR TITLE
Updating to newer syntax of node-tar

### DIFF
--- a/lib/backup-manager.js
+++ b/lib/backup-manager.js
@@ -133,10 +133,9 @@ function _backup(options, callback2) {
             path: output_destination + '.tar.gz'
         });
 
-        fstream.Reader({ 'path': output_destination, 'type': 'Directory' }) /* Read the source directory */
-            .pipe(tar.Pack())   // Convert the directory to a .tar file */
-            .pipe(zlib.Gzip())  // Compress the .tar file */
-            .pipe(writer);      // Give the output file name */
+        tar.c({gzip: true}, [output_destination])   // Convert the directory to a .tar file */
+        .pipe(zlib.Gzip())  // Compress the .tar file */
+        .pipe(writer);      // Give the output file name */
 
         writer.on('error', function(err) {
             callback2(err);


### PR DESCRIPTION
As inside the package.json node-tar is * it will break if node-tar get's installed as in my case. now it works like a charm again.